### PR TITLE
Add initial PostgreSQL schema and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# SWPPP Automation Database
+
+This project contains the base PostgreSQL schema and utilities for SWPPP automation.
+
+## Requirements
+- PostgreSQL client (`psql`)
+- Python 3 with `pip`
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running Migrations
+The schema lives in `migrations/schema.sql` and can be applied using `migrate.sh`.
+Provide a database connection URL either via the `DATABASE_URL` environment variable or as the first argument.
+
+```bash
+export DATABASE_URL=postgres://user:pass@localhost/dbname
+./migrate.sh
+```
+
+## Running Tests
+Tests verify that all schema objects exist. The tests expect the database specified by `DATABASE_URL` to already have the schema applied.
+
+```bash
+pytest tests/test_schema_integrity.py
+```

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Apply database migrations
+# Usage: DATABASE_URL=postgres://user:pass@host/db ./migrate.sh
+
+set -e
+
+DB_URL="${1:-$DATABASE_URL}"
+if [ -z "$DB_URL" ]; then
+    echo "Error: provide database url as argument or set DATABASE_URL" >&2
+    exit 1
+fi
+
+psql "$DB_URL" -f migrations/001_init.sql

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,2 @@
+-- Initial schema migration
+\i schema.sql

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1,0 +1,79 @@
+-- Schema for SWPPP automation database
+
+CREATE TABLE IF NOT EXISTS contractors (
+    contractor_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    contact_info TEXT,
+    rating NUMERIC
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+    project_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    general_contractor_id INTEGER REFERENCES contractors(contractor_id),
+    latitude NUMERIC(9,6),
+    longitude NUMERIC(9,6),
+    acres NUMERIC(10,2),
+    jurisdiction TEXT,
+    status TEXT,
+    inspection_cadence INTEGER,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS lots (
+    lot_id SERIAL PRIMARY KEY,
+    project_id INTEGER REFERENCES projects(project_id) ON DELETE CASCADE,
+    lot_number TEXT,
+    schedule TEXT,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS renewal_rules (
+    rule_id SERIAL PRIMARY KEY,
+    jurisdiction TEXT UNIQUE NOT NULL,
+    lead_time_days INTEGER NOT NULL,
+    permit_language TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dates (
+    date DATE PRIMARY KEY,
+    year INTEGER,
+    month INTEGER,
+    day INTEGER,
+    quarter INTEGER,
+    week INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS inspections (
+    inspection_id SERIAL PRIMARY KEY,
+    project_id INTEGER REFERENCES projects(project_id) ON DELETE CASCADE,
+    inspection_date TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    inspector TEXT,
+    severity TEXT,
+    findings TEXT,
+    photo_url TEXT,
+    report_url TEXT,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id SERIAL PRIMARY KEY,
+    project_id INTEGER REFERENCES projects(project_id) ON DELETE CASCADE,
+    description TEXT NOT NULL,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
+    due_date TIMESTAMP WITHOUT TIME ZONE,
+    completed_at TIMESTAMP WITHOUT TIME ZONE,
+    sla BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS versions (
+    version_id SERIAL PRIMARY KEY,
+    project_id INTEGER REFERENCES projects(project_id) ON DELETE CASCADE,
+    version_number INTEGER NOT NULL,
+    file_sha256 CHAR(64) NOT NULL,
+    envelope_id TEXT,
+    signed_at TIMESTAMP WITHOUT TIME ZONE,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-
+psycopg2-binary
+pytest

--- a/tests/test_schema_integrity.py
+++ b/tests/test_schema_integrity.py
@@ -1,0 +1,44 @@
+import os
+import psycopg2
+import pytest
+
+TABLE_COLUMNS = {
+    'contractors': ['contractor_id', 'name', 'contact_info', 'rating'],
+    'projects': ['project_id', 'name', 'owner', 'general_contractor_id', 'latitude', 'longitude', 'acres',
+                'jurisdiction', 'status', 'inspection_cadence', 'created_at'],
+    'lots': ['lot_id', 'project_id', 'lot_number', 'schedule', 'created_at'],
+    'renewal_rules': ['rule_id', 'jurisdiction', 'lead_time_days', 'permit_language'],
+    'dates': ['date', 'year', 'month', 'day', 'quarter', 'week'],
+    'inspections': ['inspection_id', 'project_id', 'inspection_date', 'inspector', 'severity', 'findings',
+                    'photo_url', 'report_url', 'created_at'],
+    'tasks': ['task_id', 'project_id', 'description', 'created_at', 'due_date', 'completed_at', 'sla'],
+    'versions': ['version_id', 'project_id', 'version_number', 'file_sha256', 'envelope_id', 'signed_at', 'created_at'],
+}
+
+
+def table_exists(cur, table_name):
+    cur.execute("SELECT to_regclass(%s)", (table_name,))
+    return cur.fetchone()[0] is not None
+
+
+def column_exists(cur, table_name, column_name):
+    cur.execute(
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = %s AND column_name = %s
+        """,
+        (table_name, column_name),
+    )
+    return cur.fetchone() is not None
+
+
+def test_schema_integrity():
+    db_url = os.environ.get('DATABASE_URL')
+    assert db_url, 'DATABASE_URL environment variable must be set for tests'
+    with psycopg2.connect(db_url) as conn:
+        with conn.cursor() as cur:
+            for table, columns in TABLE_COLUMNS.items():
+                assert table_exists(cur, table), f"Table {table} is missing"
+                for column in columns:
+                    assert column_exists(cur, table, column), f"Column {table}.{column} is missing"


### PR DESCRIPTION
## Summary
- create PostgreSQL schema and initial migration
- add migration helper script
- add schema integrity tests
- document how to run migrations and tests
- specify project requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: DATABASE_URL environment variable must be set for tests)*

------
https://chatgpt.com/codex/tasks/task_e_6864cd562d0c8320a9d8b8248ef9e238